### PR TITLE
chore: migrate Coveralls usage to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: "Coverage"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
@@ -12,7 +13,6 @@ on:
 jobs:
   coverage:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester-coverage.yml@v1
+    uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
     with:
       php: "8.4"
-      make: "init coverage"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/ui-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/ui-skeleton/master"></a>
-  <a href="https://coveralls.io/r/contributte/ui-skeleton"><img src="https://badgen.net/coveralls/c/github/contributte/ui-skeleton"></a>
+  <a href="https://codecov.io/gh/contributte/ui-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/ui-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/ui-skeleton"><img src="https://badgen.net/packagist/dm/contributte/ui-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/ui-skeleton"><img src="https://badgen.net/packagist/v/contributte/ui-skeleton"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: github-actions
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
## What changed
- switched the README coverage badge and link from Coveralls to Codecov
- updated the coverage workflow to use `contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master`
- removed the obsolete `tests/.coveralls.yml` file

## Why
- completes the remaining Coveralls-to-Codecov migration work for this repository
- aligns `contributte/ui-skeleton` with the shared coverage setup used in `contributte/vite`

Refs contributte/contributte#72