### PR TITLE
Replace phpdbg with php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`
- align this repository with contributte/contributte#73
- note local coverage verification is blocked in this environment because PHP has no Xdebug or PCOV extension loaded

## Motivation
`phpdbg` is being removed from Contributte coverage targets. This switches the project to plain `php` so coverage can run through the standard PHP binary when a supported coverage driver is available.

## Changes
- update the `coverage` target in `Makefile` to use `php`

## Testing
- [x] Tried `make coverage`
- [ ] Tests pass locally
- [ ] CI passes
- [ ] Manual verification

`make coverage` currently fails here with: `Code coverage functionality requires Xdebug or PCOV extension or PHPDBG SAPI (used php)`.