### PR TITLE
Split frontend demos by rendering mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,15 @@ dev:
 
 .PHONY: build
 build:
-	npm install
+	npm ci
 	npm run build
+
+.PHONY: verify
+verify:
+	$(MAKE) setup
+	$(MAKE) build
+	$(MAKE) tests
+	$(MAKE) qa
 
 .PHONY: assets
 assets:

--- a/app/UI/@Templates/@inertia.latte
+++ b/app/UI/@Templates/@inertia.latte
@@ -1,0 +1,15 @@
+{varType Contributte\UI\Inertia\Page $page}
+<!doctype html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>UI Skeleton</title>
+	{vitecss assets/js/app.ts}
+	{vitejs assets/js/app.ts}
+	{=inertiaHead()}
+</head>
+<body>
+	{=inertia($page)}
+</body>
+</html>

--- a/app/UI/@Templates/@inertia.latte
+++ b/app/UI/@Templates/@inertia.latte
@@ -5,8 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>UI Skeleton</title>
-	{vitecss assets/js/app.ts}
-	{vitejs assets/js/app.ts}
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+	{vitecss assets/js/site.ts}
+	{vitejs assets/js/site.ts}
+	{vitejs assets/js/inertia.ts}
 	{=inertiaHead()}
 </head>
 <body>

--- a/app/UI/@Templates/@layout.latte
+++ b/app/UI/@Templates/@layout.latte
@@ -5,12 +5,14 @@
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>{block #title|striptags}UI Skeleton{/}</title>
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+	{block #head}{/block}
 
 	<!-- CSS -->
-	{vitecss assets/js/app.ts}
+	{vitecss assets/js/site.ts}
 
 	<!-- JS -->
-	{vitejs assets/js/app.ts}
+	{vitejs assets/js/site.ts}
 </head>
 <body>
 
@@ -20,6 +22,12 @@
 			<h1 class="font-bold text-3xl">
 				Contributte / UI Skeleton
 			</h1>
+			<div class="mt-4 flex flex-wrap gap-3 text-sm">
+				<a n:href="Home:default" class="rounded-full border border-gray-200 px-4 py-2 text-gray-700 hover:border-blue-300 hover:text-blue-600">Overview</a>
+				<a n:href="Showcase:inertia" class="rounded-full border border-gray-200 px-4 py-2 text-gray-700 hover:border-blue-300 hover:text-blue-600">Inertia app</a>
+				<a n:href="Showcase:widgets" class="rounded-full border border-gray-200 px-4 py-2 text-gray-700 hover:border-blue-300 hover:text-blue-600">Widgets</a>
+				<a n:href="Showcase:vue" class="rounded-full border border-gray-200 px-4 py-2 text-gray-700 hover:border-blue-300 hover:text-blue-600">Pure Vue</a>
+			</div>
 		</div>
 
 		<div n:if="$flashes !== []" n:inner-foreach="$flashes as $flash">
@@ -39,6 +47,4 @@
 </div>
 </body>
 </html>
-
-
 

--- a/app/UI/BasePresenter.php
+++ b/app/UI/BasePresenter.php
@@ -3,8 +3,11 @@
 namespace App\UI;
 
 use Contributte\Nella\UI\NellaPresenter;
+use Contributte\UI\Inertia\Presenter\TInertiaPresenter;
 
 abstract class BasePresenter extends NellaPresenter
 {
+
+	use TInertiaPresenter;
 
 }

--- a/app/UI/Home/HomePresenter.php
+++ b/app/UI/Home/HomePresenter.php
@@ -10,12 +10,63 @@ final class HomePresenter extends BasePresenter
 	public function renderDefault(): void
 	{
 		$this->inertia('Home/Index', [
-			'title' => 'Contributte / UI Skeleton',
-			'tagline' => 'Nette, Vite and Inertia.js working together.',
-			'features' => [
-				'Protocol-correct server-side Inertia responses from contributte/ui',
-				'Vue-powered page rendering with a Vite build pipeline',
-				'Room for classic Nette components beside modern SPA navigation',
+			'title' => 'Signal Stack',
+			'tagline' => 'Three different frontend setups living side by side in one Nette application.',
+			'intro' => 'Use the homepage as a switchboard. Each route proves a different rendering model: an Inertia app, a classic Latte page enhanced by Alpine, and a pure Vue workspace mounted without Inertia.',
+			'cards' => [
+				[
+					'id' => 'inertia',
+					'eyebrow' => 'Signal Stack',
+					'title' => 'Pulse Protocol',
+					'description' => 'A real Inertia page where the presenter owns routing and payloads while Vue hydrates the application shell.',
+					'href' => $this->link('Showcase:inertia'),
+					'status' => 'Inertia',
+					'highlights' => [
+						'Presenter-fed page models',
+						'Protocol-aware lifecycle',
+						'Vue hydrated via Inertia only',
+					],
+				],
+				[
+					'id' => 'widgets',
+					'eyebrow' => 'Latte + Alpine',
+					'title' => 'Widget Workshop',
+					'description' => 'A classic server-rendered page that uses pure Latte templates and Alpine-enhanced widgets inspired by embedded-skeleton.',
+					'href' => $this->link('Showcase:widgets'),
+					'status' => 'Classic widgets',
+					'highlights' => [
+						'Pure Latte sections',
+						'Alpine collapse, dialog, tabs, and menus',
+						'Copy-paste friendly widget examples',
+					],
+				],
+				[
+					'id' => 'vue',
+					'eyebrow' => 'Pure Vue',
+					'title' => 'Vue Workbench',
+					'description' => 'A standalone Vue app mounted into a normal Latte page, without Inertia in the middle.',
+					'href' => $this->link('Showcase:vue'),
+					'status' => 'Vue app',
+					'highlights' => [
+						'Dedicated Vue entrypoint',
+						'Client-owned workspace state',
+						'No Inertia protocol involved',
+					],
+				],
+			],
+			'stackPillars' => [
+				[
+					'label' => 'Inertia app',
+					'description' => 'Use when presenters should still own navigation, links, shared props, and protocol behavior.',
+				],
+				[
+					'label' => 'Latte + Alpine widgets',
+					'description' => 'Use when the page should stay fundamentally server-rendered and only needs light interaction primitives.',
+				],
+				[
+					'label' => 'Pure Vue workspace',
+					'description' => 'Use when the page is a self-contained client application with local state and denser interactivity.',
+				],
 			],
 			'links' => [
 				['label' => 'Contributte UI', 'url' => 'https://github.com/contributte/ui'],

--- a/app/UI/Home/HomePresenter.php
+++ b/app/UI/Home/HomePresenter.php
@@ -4,7 +4,25 @@ namespace App\UI\Home;
 
 use App\UI\BasePresenter;
 
-class HomePresenter extends BasePresenter
+final class HomePresenter extends BasePresenter
 {
+
+	public function renderDefault(): void
+	{
+		$this->inertia('Home/Index', [
+			'title' => 'Contributte / UI Skeleton',
+			'tagline' => 'Nette, Vite and Inertia.js working together.',
+			'features' => [
+				'Protocol-correct server-side Inertia responses from contributte/ui',
+				'Vue-powered page rendering with a Vite build pipeline',
+				'Room for classic Nette components beside modern SPA navigation',
+			],
+			'links' => [
+				['label' => 'Contributte UI', 'url' => 'https://github.com/contributte/ui'],
+				['label' => 'Inertia.js', 'url' => 'https://inertiajs.com/'],
+				['label' => 'Nette Framework', 'url' => 'https://nette.org/'],
+			],
+		]);
+	}
 
 }

--- a/app/UI/Home/Templates/default.latte
+++ b/app/UI/Home/Templates/default.latte
@@ -1,5 +1,0 @@
-{block #content}
-
-<div>
-	Hello!
-</div>

--- a/app/UI/Showcase/ShowcasePresenter.php
+++ b/app/UI/Showcase/ShowcasePresenter.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types = 1);
+
+namespace App\UI\Showcase;
+
+use App\UI\BasePresenter;
+use Nette\Utils\Json;
+
+final class ShowcasePresenter extends BasePresenter
+{
+
+	public bool $autoCanonicalize = false;
+
+	public function renderInertia(): void
+	{
+		$this->inertia('Showcase/Inertia', [
+			'navigation' => $this->createNavigation('inertia'),
+			'hero' => [
+				'eyebrow' => 'Inertia app',
+				'title' => 'Pulse Protocol',
+				'tagline' => 'A real Inertia surface where Nette still authors the route, payload, and links.',
+				'summary' => 'This page intentionally stays inside the Inertia model. The presenter decides the component, shared props stay server-driven, and Vue hydrates only after the protocol does its work.',
+			],
+			'pillars' => [
+				[
+					'title' => 'Presenter-fed page models',
+					'description' => 'Nette decides the page component, shape of props, and internal URLs before Vue hydrates anything.',
+				],
+				[
+					'title' => 'Protocol-aware responses',
+					'description' => 'The adapter handles JSON visits, version mismatches, and the HTML bootstrap shell through one integration point.',
+				],
+				[
+					'title' => 'Selective page refresh',
+					'description' => 'Partial reloads and lazy props keep the server in charge while reducing the amount of work the page needs.',
+				],
+			],
+			'flow' => [
+				[
+					'label' => 'Presenter intent',
+					'description' => 'A presenter action prepares props, links, and component metadata.',
+				],
+				[
+					'label' => 'Inertia envelope',
+					'description' => 'The response becomes HTML or JSON depending on the request headers.',
+				],
+				[
+					'label' => 'Hydrated page',
+					'description' => 'Vue resolves the matching page module and keeps transitions feeling instantaneous.',
+				],
+			],
+			'examples' => [
+				[
+					'title' => 'Shared props',
+					'summary' => 'Flash errors, auth context, and nav items can be pushed from the presenter layer without manual JSON plumbing.',
+				],
+				[
+					'title' => 'Version gating',
+					'summary' => 'Stale frontend assets trigger a controlled 409 refresh instead of letting mismatched bundles drift.',
+				],
+				[
+					'title' => 'Page-to-page navigation',
+					'summary' => 'Use Inertia links for crisp transitions while preserving Nette link generation on the server.',
+				],
+			],
+			'resources' => [
+				['label' => 'Inertia Protocol', 'url' => 'https://inertiajs.com/the-protocol'],
+				['label' => 'Contributte UI', 'url' => 'https://github.com/contributte/ui'],
+			],
+		]);
+	}
+
+	public function renderWidgets(): void
+	{
+		$this->template->navigation = $this->createNavigation('widgets');
+		$this->template->title = 'Widget Workshop';
+	}
+
+	public function renderVue(): void
+	{
+		$this->template->navigation = $this->createNavigation('vue');
+		$this->template->title = 'Vue Workbench';
+		$payload = [
+			'metrics' => [
+				['label' => 'Open experiments', 'value' => '12', 'change' => '+3 this week'],
+				['label' => 'Healthy flows', 'value' => '94%', 'change' => '+6%'],
+				['label' => 'Queued actions', 'value' => '08', 'change' => '2 urgent'],
+			],
+			'panels' => [
+				[
+					'title' => 'Active boards',
+					'description' => 'Dense, filterable collections with local sorting and progressive disclosure.',
+				],
+				[
+					'title' => 'Focus tools',
+					'description' => 'Stateful controls, optimistic toggles, and computed summaries belong here.',
+				],
+				[
+					'title' => 'Decision sidebars',
+					'description' => 'Use compact side panels for approvals, comments, and next steps.',
+				],
+			],
+			'activity' => [
+				['title' => 'Release candidate generated', 'time' => '5m ago', 'state' => 'ok'],
+				['title' => 'Design token sync pending review', 'time' => '18m ago', 'state' => 'pending'],
+				['title' => 'Tooltip wording mismatch detected', 'time' => '42m ago', 'state' => 'warning'],
+				['title' => 'Accessibility pass completed', 'time' => '1h ago', 'state' => 'ok'],
+			],
+		];
+
+		$this->template->vuePayloadJson = Json::encode($payload);
+	}
+
+	/**
+	 * @return list<array{key: string, label: string, href: string, active: bool}>
+	 */
+	private function createNavigation(string $active): array
+	{
+		return [
+			[
+				'key' => 'inertia',
+				'label' => 'Pulse Protocol',
+				'href' => $this->link('Showcase:inertia'),
+				'active' => $active === 'inertia',
+			],
+			[
+				'key' => 'widgets',
+				'label' => 'Widget Workshop',
+				'href' => $this->link('Showcase:widgets'),
+				'active' => $active === 'widgets',
+			],
+			[
+				'key' => 'vue',
+				'label' => 'Vue Workbench',
+				'href' => $this->link('Showcase:vue'),
+				'active' => $active === 'vue',
+			],
+		];
+	}
+
+}

--- a/app/UI/Showcase/Templates/vue.latte
+++ b/app/UI/Showcase/Templates/vue.latte
@@ -1,0 +1,10 @@
+{block #title}{$title}{/block}
+
+{block #head}
+	{vitejs assets/js/vue-demo.ts}
+{/block}
+
+{block #content}
+	<script type="application/json" id="vue-demo-props">{$vuePayloadJson|noescape}</script>
+	<div id="vue-demo"></div>
+{/block}

--- a/app/UI/Showcase/Templates/widgets.latte
+++ b/app/UI/Showcase/Templates/widgets.latte
@@ -1,0 +1,144 @@
+{block #title}{$title}{/block}
+
+{varType array<array{key: string, label: string, href: string, active: bool}> $navigation}
+
+{block #content}
+	<div class="space-y-10">
+		<section class="rounded-[2rem] border border-gray-200 bg-white p-8 shadow-sm">
+			<div class="max-w-4xl space-y-4">
+				<p class="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-600">Latte + Alpine widgets</p>
+				<h2 class="text-4xl font-black tracking-tight text-gray-950">Widget Workshop</h2>
+				<p class="text-lg leading-8 text-gray-600">This page stays completely server-rendered. Latte shapes the markup, Alpine adds the interaction layer, and every example remains easy to lift into a classic Nette application.</p>
+			</div>
+
+			<nav class="mt-8 flex flex-wrap gap-3 text-sm">
+				<a
+					n:foreach="$navigation as $item"
+					href="{$item['href']}"
+					n:class="'rounded-full border px-4 py-2 transition', $item['active'] ? 'border-cyan-300 bg-cyan-50 text-cyan-700', !$item['active'] ? 'border-gray-200 text-gray-700 hover:border-cyan-300 hover:text-cyan-700'"
+				>
+					{$item['label']}
+				</a>
+			</nav>
+		</section>
+
+		<section class="grid gap-8 xl:grid-cols-[220px_minmax(0,1fr)]">
+			<aside class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm xl:sticky xl:top-6 xl:self-start">
+				<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Quick jump</p>
+				<nav class="mt-5 space-y-2 text-sm">
+					<a href="#collapse" class="block rounded-xl px-3 py-2 text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Collapse</a>
+					<a href="#tabs" class="block rounded-xl px-3 py-2 text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Tabs</a>
+					<a href="#dropdown" class="block rounded-xl px-3 py-2 text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Dropdown</a>
+					<a href="#modal" class="block rounded-xl px-3 py-2 text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Modal</a>
+					<a href="#tooltip" class="block rounded-xl px-3 py-2 text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Tooltip</a>
+				</nav>
+
+				<div class="mt-8 rounded-2xl border border-dashed border-cyan-200 bg-cyan-50 p-4 text-sm leading-7 text-cyan-900">
+					These examples are intentionally simple: server-rendered first, Alpine-enhanced second.
+				</div>
+			</aside>
+
+			<div class="space-y-8">
+				<section id="collapse" x-data="{ expanded: false }" class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+					<div class="max-w-3xl">
+						<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Disclosure</p>
+						<h3 class="mt-3 text-2xl font-bold text-gray-950">Collapse</h3>
+						<p class="mt-3 text-sm leading-7 text-gray-600">Great for advanced filters, FAQs, or secondary detail that should stay hidden by default.</p>
+					</div>
+
+					<button @click="expanded = !expanded" class="mt-6 flex w-full items-center justify-between rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-left text-sm font-medium text-gray-900 transition hover:border-cyan-300 hover:bg-cyan-50">
+						<span>What should a reusable widget optimize for?</span>
+						<span x-text="expanded ? 'Hide' : 'Reveal'"></span>
+					</button>
+
+					<div x-show="expanded" x-collapse x-cloak class="mt-4 rounded-2xl border border-cyan-200 bg-cyan-50 p-4 text-sm leading-7 text-cyan-950">
+						Predictable behavior, clear escape hatches, and markup that stays understandable to backend-oriented teams.
+					</div>
+				</section>
+
+				<section id="tabs" x-data="{ tab: 'overview' }" class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+					<div class="max-w-3xl">
+						<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Navigation</p>
+						<h3 class="mt-3 text-2xl font-bold text-gray-950">Tabs</h3>
+						<p class="mt-3 text-sm leading-7 text-gray-600">Tabs work well when related content belongs in one surface and should not force a page transition.</p>
+					</div>
+
+					<div class="mt-6 inline-flex flex-wrap rounded-full border border-gray-200 bg-gray-50 p-1">
+						<button @click="tab = 'overview'" :class="tab === 'overview' ? 'bg-cyan-100 text-cyan-900' : 'text-gray-500 hover:text-gray-900'" class="rounded-full px-4 py-2 text-sm transition">Overview</button>
+						<button @click="tab = 'patterns'" :class="tab === 'patterns' ? 'bg-cyan-100 text-cyan-900' : 'text-gray-500 hover:text-gray-900'" class="rounded-full px-4 py-2 text-sm transition">Patterns</button>
+						<button @click="tab = 'a11y'" :class="tab === 'a11y' ? 'bg-cyan-100 text-cyan-900' : 'text-gray-500 hover:text-gray-900'" class="rounded-full px-4 py-2 text-sm transition">Accessibility</button>
+					</div>
+
+					<div class="mt-4 rounded-2xl border border-gray-200 bg-gray-50 p-4 text-sm leading-7 text-gray-700">
+						<p x-show="tab === 'overview'">Use tabs for settings, profiles, or compact docs where context should stay visible.</p>
+						<p x-show="tab === 'patterns'" x-cloak>Keep labels short, content scoped, and avoid turning tabs into hidden site navigation.</p>
+						<p x-show="tab === 'a11y'" x-cloak>Support focus visibility and preserve a logical reading order for keyboard users.</p>
+					</div>
+				</section>
+
+				<section id="dropdown" x-data="{ open: false }" @keydown.escape.window="open = false" class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+					<div class="max-w-3xl">
+						<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Floating UI</p>
+						<h3 class="mt-3 text-2xl font-bold text-gray-950">Dropdown</h3>
+						<p class="mt-3 text-sm leading-7 text-gray-600">Contextual menus should stay compact, dismiss easily, and remain attached to the user action that opened them.</p>
+					</div>
+
+					<div class="relative mt-6 inline-block">
+						<button @click="open = !open" class="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm font-medium text-gray-900 transition hover:border-cyan-300 hover:bg-cyan-50">Open quick actions</button>
+						<div x-show="open" x-cloak @click.away="open = false" class="absolute left-0 top-14 z-10 w-64 rounded-2xl border border-gray-200 bg-white p-2 shadow-xl">
+							<a href="#" class="block rounded-xl px-3 py-2 text-sm text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Inspect widget state</a>
+							<a href="#" class="mt-1 block rounded-xl px-3 py-2 text-sm text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Duplicate pattern notes</a>
+							<a href="#modal" class="mt-1 block rounded-xl px-3 py-2 text-sm text-gray-700 transition hover:bg-cyan-50 hover:text-cyan-700">Jump to dialog example</a>
+						</div>
+					</div>
+				</section>
+
+				<section id="modal" x-data="{ open: false }" @keydown.escape.window="open = false" class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+					<div class="max-w-3xl">
+						<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Overlay</p>
+						<h3 class="mt-3 text-2xl font-bold text-gray-950">Modal</h3>
+						<p class="mt-3 text-sm leading-7 text-gray-600">Dialogs should be used sparingly for decisions that truly need focus and separation from the rest of the page.</p>
+					</div>
+
+					<button @click="open = true" class="mt-6 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm font-medium text-gray-900 transition hover:border-cyan-300 hover:bg-cyan-50">Launch review dialog</button>
+
+					<div x-show="open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-gray-950/50 px-4">
+						<div @click.away="open = false" class="w-full max-w-lg rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-2xl">
+							<div class="flex items-center justify-between gap-4">
+								<div>
+									<p class="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-600">Review</p>
+									<h4 class="mt-3 text-2xl font-bold text-gray-950">Approve this widget pattern?</h4>
+								</div>
+								<button @click="open = false" class="rounded-full border border-gray-200 px-3 py-2 text-sm text-gray-600">Close</button>
+							</div>
+
+							<p class="mt-5 text-sm leading-7 text-gray-600">The goal is to keep the contract tiny: open, close, click-away dismissal, and focus staying inside the dialog while it is visible.</p>
+
+							<div class="mt-6 flex justify-end gap-3">
+								<button @click="open = false" class="rounded-full border border-gray-200 px-4 py-2 text-sm text-gray-600">Not yet</button>
+								<button @click="open = false" class="rounded-full border border-cyan-300 bg-cyan-50 px-4 py-2 text-sm font-medium text-cyan-700">Looks good</button>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section id="tooltip" x-data="{ open: false }" class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+					<div class="max-w-3xl">
+						<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Micro guidance</p>
+						<h3 class="mt-3 text-2xl font-bold text-gray-950">Tooltip</h3>
+						<p class="mt-3 text-sm leading-7 text-gray-600">Tooltips are for lightweight hints only. If content is essential, it should be visible without hover.</p>
+					</div>
+
+					<div class="mt-6 flex items-center gap-4">
+						<div class="relative inline-block">
+							<button @mouseenter="open = true" @mouseleave="open = false" class="rounded-full border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-900 transition hover:border-cyan-300 hover:bg-cyan-50">Hover for hint</button>
+							<div x-show="open" x-cloak class="absolute left-1/2 top-full z-10 mt-3 w-64 -translate-x-1/2 rounded-xl border border-cyan-200 bg-cyan-50 px-3 py-2 text-xs leading-6 text-cyan-950 shadow-lg">
+								Use tooltips for microcopy, not for actions, warnings, or required instructions.
+							</div>
+						</div>
+					</div>
+				</section>
+			</div>
+		</section>
+	</div>
+{/block}

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -3,4 +3,18 @@
 @tailwind utilities;
 
 @layer base {
+	body {
+		@apply min-h-screen bg-gray-900 text-gray-100;
+		background-image:
+			radial-gradient(circle at top, rgba(245, 158, 11, 0.28), transparent 32%),
+			linear-gradient(135deg, rgba(12, 10, 9, 0.96), rgba(28, 25, 23, 0.92));
+	}
+
+	a {
+		@apply transition-colors duration-200;
+	}
+
+	::selection {
+		background: rgba(251, 191, 36, 0.28);
+	}
 }

--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -1,25 +1,22 @@
-import { Alpine } from "./3rd/alpine";
-
-// UI
-import { init as initNette } from "./ui/nette";
-
-// CSS
 import "./../css/tailwind.css";
+import { createApp, h } from "vue";
+import { createInertiaApp } from "@inertiajs/vue3";
 
-window.addEventListener("load", () => {
-	// Alpine global
-	// @ts-ignore
-	window.Alpine = Alpine;
+const pages = import.meta.glob("./pages/**/*.vue");
 
-	// Alpine data
-	Alpine.data('layout', () => ({}));
+void createInertiaApp({
+	resolve: async (name) => {
+		const page = pages[`./pages/${name}.vue`];
 
-	// Initialize Alpine
-	Alpine.start();
+		if (!page) {
+			throw new Error(`Unknown Inertia page: ${name}`);
+		}
+
+		return await page();
+	},
+	setup({ el, App, props, plugin }) {
+		createApp({ render: () => h(App, props) })
+			.use(plugin)
+			.mount(el);
+	},
 });
-
-document.addEventListener("DOMContentLoaded", () => {
-	// UI
-	initNette();
-});
-

--- a/assets/js/components/showcase/GatewayCard.vue
+++ b/assets/js/components/showcase/GatewayCard.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { Link } from "@inertiajs/vue3";
+
+defineProps<{
+	eyebrow: string;
+	title: string;
+	description: string;
+	href: string;
+	status: string;
+	highlights: string[];
+	accent: "amber" | "cyan" | "violet";
+}>();
+
+const accentClasses = {
+	amber: "from-yellow-300/20 via-yellow-400/5 to-transparent border-yellow-300/20 text-yellow-100 hover:border-yellow-300/40 hover:bg-yellow-300/10",
+	cyan: "from-cyan-300/20 via-sky-400/5 to-transparent border-cyan-300/20 text-cyan-100 hover:border-cyan-300/40 hover:bg-cyan-300/10",
+	violet: "from-violet-300/20 via-fuchsia-500/5 to-transparent border-violet-300/20 text-violet-100 hover:border-violet-300/40 hover:bg-violet-300/10",
+};
+</script>
+
+<template>
+	<Link :href="href" class="group block rounded-[1.75rem] border bg-white/5 p-6 transition duration-300" :class="accentClasses[accent]">
+		<div class="space-y-5">
+			<div class="flex items-center justify-between gap-4">
+				<div>
+					<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-400">
+						{{ eyebrow }}
+					</p>
+					<h2 class="mt-3 text-2xl font-bold text-white sm:text-3xl">
+						{{ title }}
+					</h2>
+				</div>
+				<span class="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs font-medium text-gray-200">
+					{{ status }}
+				</span>
+			</div>
+
+			<p class="text-base leading-7 text-gray-300">
+				{{ description }}
+			</p>
+
+			<ul class="grid gap-2 text-sm leading-6 text-gray-300">
+				<li v-for="highlight in highlights" :key="highlight" class="flex items-start gap-3">
+					<span class="mt-1 h-2 w-2 rounded-full bg-current"></span>
+					<span>{{ highlight }}</span>
+				</li>
+			</ul>
+
+			<div class="pt-2 text-sm font-medium text-white transition group-hover:translate-x-1">
+				Open module ->
+			</div>
+		</div>
+	</Link>
+</template>

--- a/assets/js/components/showcase/SectionHeading.vue
+++ b/assets/js/components/showcase/SectionHeading.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+defineProps<{
+	eyebrow: string;
+	title: string;
+	description: string;
+}>();
+</script>
+
+<template>
+	<div class="max-w-3xl space-y-3">
+		<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">
+			{{ eyebrow }}
+		</p>
+		<h2 class="text-2xl font-bold text-white sm:text-3xl">
+			{{ title }}
+		</h2>
+		<p class="text-base leading-7 text-gray-400 sm:text-lg">
+			{{ description }}
+		</p>
+	</div>
+</template>

--- a/assets/js/components/showcase/ShowcaseShell.vue
+++ b/assets/js/components/showcase/ShowcaseShell.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { Link } from "@inertiajs/vue3";
+
+type NavigationItem = {
+	key: string;
+	label: string;
+	href: string;
+	active: boolean;
+};
+
+withDefaults(defineProps<{
+	eyebrow: string;
+	title: string;
+	tagline: string;
+	summary?: string;
+	navigation?: NavigationItem[];
+	theme?: "amber" | "cyan" | "violet";
+}>(), {
+	summary: "",
+	navigation: () => [],
+	theme: "amber",
+});
+
+const themeClasses = {
+	amber: {
+		pill: "border-yellow-300/30 bg-yellow-300/10 text-yellow-200",
+		glow: "shadow-yellow-500/10",
+		panel: "from-yellow-300/16 via-transparent to-sky-400/16",
+		active: "border-yellow-300/40 bg-yellow-300/15 text-yellow-100",
+	},
+	cyan: {
+		pill: "border-cyan-300/30 bg-cyan-300/10 text-cyan-200",
+		glow: "shadow-cyan-500/10",
+		panel: "from-cyan-300/16 via-transparent to-blue-500/16",
+		active: "border-cyan-300/40 bg-cyan-300/15 text-cyan-100",
+	},
+	violet: {
+		pill: "border-violet-300/30 bg-violet-300/10 text-violet-200",
+		glow: "shadow-violet-500/10",
+		panel: "from-violet-300/16 via-transparent to-fuchsia-500/16",
+		active: "border-violet-300/40 bg-violet-300/15 text-violet-100",
+	},
+};
+</script>
+
+<template>
+	<div class="min-h-screen overflow-hidden">
+		<div class="mx-auto flex min-h-screen max-w-7xl flex-col px-6 py-8 sm:px-10 lg:px-12">
+			<div class="mb-6 flex flex-wrap items-center justify-between gap-3 text-sm text-gray-400">
+				<Link
+					href="/"
+					class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 font-medium text-gray-100 transition hover:border-white/20 hover:bg-white/10"
+				>
+					<span class="text-yellow-200">Signal Stack</span>
+					<span class="text-gray-500">/</span>
+					<span>Contributte UI Skeleton</span>
+				</Link>
+
+				<nav v-if="navigation.length > 0" class="flex flex-wrap gap-2">
+					<Link
+						v-for="item in navigation"
+						:key="item.key"
+						:href="item.href"
+						class="rounded-full border px-4 py-2 transition"
+						:class="item.active ? themeClasses[theme].active : 'border-white/10 bg-white/5 text-gray-300 hover:border-white/20 hover:bg-white/10 hover:text-white'"
+					>
+						{{ item.label }}
+					</Link>
+				</nav>
+			</div>
+
+			<div class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 shadow-2xl backdrop-blur" :class="themeClasses[theme].glow">
+				<div class="absolute inset-0 bg-gradient-to-br" :class="themeClasses[theme].panel"></div>
+				<div class="relative px-8 py-10 md:px-12 md:py-14">
+					<div class="max-w-4xl space-y-5">
+						<p class="inline-flex items-center rounded-full border px-4 py-1 text-xs font-semibold uppercase tracking-[0.28em]" :class="themeClasses[theme].pill">
+							{{ eyebrow }}
+						</p>
+						<h1 class="max-w-4xl text-4xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
+							{{ title }}
+						</h1>
+						<p class="max-w-3xl text-lg leading-8 text-gray-200 sm:text-xl">
+							{{ tagline }}
+						</p>
+						<p v-if="summary" class="max-w-3xl text-base leading-7 text-gray-400 sm:text-lg">
+							{{ summary }}
+						</p>
+					</div>
+
+					<div class="mt-10">
+						<slot />
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/assets/js/inertia.ts
+++ b/assets/js/inertia.ts
@@ -1,4 +1,3 @@
-import "./../css/tailwind.css";
 import { createApp, h } from "vue";
 import { createInertiaApp } from "@inertiajs/vue3";
 

--- a/assets/js/pages/Home/Index.vue
+++ b/assets/js/pages/Home/Index.vue
@@ -1,77 +1,111 @@
 <script setup lang="ts">
+import GatewayCard from "@/components/showcase/GatewayCard.vue";
+import SectionHeading from "@/components/showcase/SectionHeading.vue";
+import ShowcaseShell from "@/components/showcase/ShowcaseShell.vue";
+
 defineProps<{
 	title: string;
 	tagline: string;
-	features: string[];
+	intro: string;
+	cards: Array<{
+		id: string;
+		eyebrow: string;
+		title: string;
+		description: string;
+		href: string;
+		status: string;
+		highlights: string[];
+	}>;
+	stackPillars: Array<{
+		label: string;
+		description: string;
+	}>;
 	links: Array<{
 		label: string;
 		url: string;
 	}>;
 }>();
+
+const accents: Record<string, "amber" | "cyan" | "violet"> = {
+	inertia: "amber",
+	widgets: "cyan",
+	vue: "violet",
+};
 </script>
 
 <template>
-	<div class="min-h-screen overflow-hidden">
-		<div class="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-6 py-12 sm:px-10 lg:px-12">
-			<div class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 shadow-2xl shadow-yellow-500/10 backdrop-blur">
-				<div class="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(251,191,36,0.22),_transparent_30%),radial-gradient(circle_at_bottom_left,_rgba(14,165,233,0.18),_transparent_28%)]"></div>
-				<div class="relative grid gap-10 px-8 py-10 md:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)] md:px-12 md:py-14">
-					<section class="space-y-8">
-						<div class="space-y-4">
-							<p class="inline-flex items-center rounded-full border border-yellow-300/30 bg-yellow-300/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-yellow-200">
-								Inertia demo
+	<ShowcaseShell
+		eyebrow="Signal Stack"
+		:title="title"
+		:tagline="tagline"
+		:summary="intro"
+		theme="amber"
+	>
+		<div class="space-y-14">
+			<section class="grid gap-5 lg:grid-cols-3">
+				<GatewayCard
+					v-for="card in cards"
+					:key="card.id"
+					:eyebrow="card.eyebrow"
+					:title="card.title"
+					:description="card.description"
+					:href="card.href"
+					:status="card.status"
+					:highlights="card.highlights"
+					:accent="accents[card.id] ?? 'amber'"
+				/>
+			</section>
+
+			<section class="grid gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)]">
+				<div class="space-y-6 rounded-[1.75rem] border border-white/10 bg-black/20 p-6 sm:p-8">
+					<SectionHeading
+						eyebrow="Why this skeleton exists"
+						title="Three rendering models, one repo"
+						description="Each destination is intentionally different. One uses the Inertia protocol, one stays classic with Latte and Alpine, and one mounts a standalone Vue workspace without Inertia."
+					/>
+
+					<div class="grid gap-4">
+						<article
+							v-for="pillar in stackPillars"
+							:key="pillar.label"
+							class="rounded-2xl border border-white/10 bg-white/5 p-5"
+						>
+							<h3 class="text-lg font-semibold text-white">
+								{{ pillar.label }}
+							</h3>
+							<p class="mt-2 text-sm leading-7 text-gray-400">
+								{{ pillar.description }}
 							</p>
-							<h1 class="max-w-3xl text-4xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
-								{{ title }}
-							</h1>
-							<p class="max-w-2xl text-lg leading-8 text-gray-300 sm:text-xl">
-								{{ tagline }}
-							</p>
-						</div>
-
-						<div class="grid gap-4 sm:grid-cols-3">
-							<article
-								v-for="feature in features"
-								:key="feature"
-								class="rounded-2xl border border-white/10 bg-gray-900/55 p-5 text-sm leading-6 text-gray-200"
-							>
-								{{ feature }}
-							</article>
-						</div>
-					</section>
-
-					<aside class="rounded-[1.5rem] border border-white/10 bg-black/20 p-6">
-						<div class="space-y-5">
-							<div>
-								<p class="text-xs font-semibold uppercase tracking-[0.28em] text-blue-200/80">
-									Explore
-								</p>
-								<h2 class="mt-3 text-2xl font-bold text-white">
-									Useful links
-								</h2>
-							</div>
-
-							<nav class="space-y-3">
-								<a
-									v-for="link in links"
-									:key="link.url"
-									:href="link.url"
-									target="_blank"
-									rel="noreferrer noopener"
-									class="group flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-gray-100 hover:border-yellow-300/40 hover:bg-yellow-300/10"
-								>
-									<span class="font-medium">{{ link.label }}</span>
-									<span class="text-sm text-gray-400 transition group-hover:text-yellow-200">Open</span>
-								</a>
-							</nav>
-
-							<p class="text-sm leading-7 text-gray-400">
-								This page is rendered by a Nette presenter and hydrated by Vue through Inertia.js.
-							</p>
-						</div>
-					</aside>
+						</article>
+					</div>
 				</div>
-			</div>
+
+				<aside class="space-y-6 rounded-[1.75rem] border border-white/10 bg-white/5 p-6 sm:p-8">
+					<SectionHeading
+						eyebrow="External references"
+						title="Keep one foot in the ecosystem"
+						description="The showcase pages stay local and opinionated, but the underlying ideas are grounded in the broader Inertia, Nette, and Contributte ecosystem."
+					/>
+
+					<nav class="space-y-3">
+						<a
+							v-for="link in links"
+							:key="link.url"
+							:href="link.url"
+							target="_blank"
+							rel="noreferrer noopener"
+							class="group flex items-center justify-between rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-gray-100 transition hover:border-yellow-300/30 hover:bg-yellow-300/10"
+						>
+							<span class="font-medium">{{ link.label }}</span>
+							<span class="text-sm text-gray-400 transition group-hover:text-yellow-200">Open</span>
+						</a>
+					</nav>
+
+					<div class="rounded-2xl border border-dashed border-white/10 bg-black/20 p-5 text-sm leading-7 text-gray-400">
+						Start with <span class="font-semibold text-yellow-100">Pulse Protocol</span> for the full Inertia app, move to <span class="font-semibold text-cyan-100">Widget Workshop</span> for pure Latte plus Alpine patterns, and end in <span class="font-semibold text-violet-100">Vue Workbench</span> for a client-owned workspace without Inertia.
+					</div>
+				</aside>
+			</section>
 		</div>
-	</div>
+	</ShowcaseShell>
 </template>

--- a/assets/js/pages/Home/Index.vue
+++ b/assets/js/pages/Home/Index.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+defineProps<{
+	title: string;
+	tagline: string;
+	features: string[];
+	links: Array<{
+		label: string;
+		url: string;
+	}>;
+}>();
+</script>
+
+<template>
+	<div class="min-h-screen overflow-hidden">
+		<div class="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-6 py-12 sm:px-10 lg:px-12">
+			<div class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 shadow-2xl shadow-yellow-500/10 backdrop-blur">
+				<div class="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(251,191,36,0.22),_transparent_30%),radial-gradient(circle_at_bottom_left,_rgba(14,165,233,0.18),_transparent_28%)]"></div>
+				<div class="relative grid gap-10 px-8 py-10 md:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)] md:px-12 md:py-14">
+					<section class="space-y-8">
+						<div class="space-y-4">
+							<p class="inline-flex items-center rounded-full border border-yellow-300/30 bg-yellow-300/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-yellow-200">
+								Inertia demo
+							</p>
+							<h1 class="max-w-3xl text-4xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
+								{{ title }}
+							</h1>
+							<p class="max-w-2xl text-lg leading-8 text-gray-300 sm:text-xl">
+								{{ tagline }}
+							</p>
+						</div>
+
+						<div class="grid gap-4 sm:grid-cols-3">
+							<article
+								v-for="feature in features"
+								:key="feature"
+								class="rounded-2xl border border-white/10 bg-gray-900/55 p-5 text-sm leading-6 text-gray-200"
+							>
+								{{ feature }}
+							</article>
+						</div>
+					</section>
+
+					<aside class="rounded-[1.5rem] border border-white/10 bg-black/20 p-6">
+						<div class="space-y-5">
+							<div>
+								<p class="text-xs font-semibold uppercase tracking-[0.28em] text-blue-200/80">
+									Explore
+								</p>
+								<h2 class="mt-3 text-2xl font-bold text-white">
+									Useful links
+								</h2>
+							</div>
+
+							<nav class="space-y-3">
+								<a
+									v-for="link in links"
+									:key="link.url"
+									:href="link.url"
+									target="_blank"
+									rel="noreferrer noopener"
+									class="group flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-gray-100 hover:border-yellow-300/40 hover:bg-yellow-300/10"
+								>
+									<span class="font-medium">{{ link.label }}</span>
+									<span class="text-sm text-gray-400 transition group-hover:text-yellow-200">Open</span>
+								</a>
+							</nav>
+
+							<p class="text-sm leading-7 text-gray-400">
+								This page is rendered by a Nette presenter and hydrated by Vue through Inertia.js.
+							</p>
+						</div>
+					</aside>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/assets/js/pages/Showcase/Inertia.vue
+++ b/assets/js/pages/Showcase/Inertia.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { Link } from "@inertiajs/vue3";
+import SectionHeading from "@/components/showcase/SectionHeading.vue";
+import ShowcaseShell from "@/components/showcase/ShowcaseShell.vue";
+
+defineProps<{
+	navigation: Array<{
+		key: string;
+		label: string;
+		href: string;
+		active: boolean;
+	}>;
+	hero: {
+		eyebrow: string;
+		title: string;
+		tagline: string;
+		summary: string;
+	};
+	pillars: Array<{
+		title: string;
+		description: string;
+	}>;
+	flow: Array<{
+		label: string;
+		description: string;
+	}>;
+	examples: Array<{
+		title: string;
+		summary: string;
+	}>;
+	resources: Array<{
+		label: string;
+		url: string;
+	}>;
+}>();
+</script>
+
+<template>
+	<ShowcaseShell
+		:navigation="navigation"
+		:eyebrow="hero.eyebrow"
+		:title="hero.title"
+		:tagline="hero.tagline"
+		:summary="hero.summary"
+		theme="amber"
+	>
+		<div class="grid gap-8 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+			<div class="space-y-8">
+				<section class="rounded-[1.75rem] border border-white/10 bg-black/20 p-6 sm:p-8">
+					<SectionHeading
+						eyebrow="Lifecycle"
+						title="From Nette intent to hydrated page"
+						description="The point is not to erase the server. The point is to let the server own intent while the client owns polish."
+					/>
+
+					<ol class="mt-8 space-y-4">
+						<li v-for="(item, index) in flow" :key="item.label" class="flex gap-4 rounded-2xl border border-white/10 bg-white/5 p-5">
+							<div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-yellow-300/30 bg-yellow-300/10 font-semibold text-yellow-200">
+								{{ index + 1 }}
+							</div>
+							<div>
+								<h3 class="text-lg font-semibold text-white">
+									{{ item.label }}
+								</h3>
+								<p class="mt-2 text-sm leading-7 text-gray-400">
+									{{ item.description }}
+								</p>
+							</div>
+						</li>
+					</ol>
+				</section>
+
+				<section class="rounded-[1.75rem] border border-white/10 bg-white/5 p-6 sm:p-8">
+					<SectionHeading
+						eyebrow="Feature pillars"
+						title="Why this module matters"
+						description="Each pillar corresponds to behavior already implemented in the server adapter and surfaced by this skeleton."
+					/>
+
+					<div class="mt-8 grid gap-4 sm:grid-cols-3">
+						<article v-for="pillar in pillars" :key="pillar.title" class="rounded-2xl border border-white/10 bg-black/20 p-5">
+							<h3 class="text-lg font-semibold text-white">
+								{{ pillar.title }}
+							</h3>
+							<p class="mt-2 text-sm leading-7 text-gray-400">
+								{{ pillar.description }}
+							</p>
+						</article>
+					</div>
+				</section>
+			</div>
+
+			<aside class="space-y-8">
+				<section class="rounded-[1.75rem] border border-white/10 bg-black/20 p-6 sm:p-8">
+					<SectionHeading
+						eyebrow="Practical patterns"
+						title="What to carry into real pages"
+						description="These examples describe the shape of useful Inertia pages in a Nette application, not just the protocol itself."
+					/>
+
+					<div class="mt-8 space-y-4">
+						<article v-for="example in examples" :key="example.title" class="rounded-2xl border border-white/10 bg-white/5 p-5">
+							<h3 class="text-lg font-semibold text-white">
+								{{ example.title }}
+							</h3>
+							<p class="mt-2 text-sm leading-7 text-gray-400">
+								{{ example.summary }}
+							</p>
+						</article>
+					</div>
+				</section>
+
+				<section class="rounded-[1.75rem] border border-white/10 bg-white/5 p-6 sm:p-8">
+					<SectionHeading
+						eyebrow="Explore further"
+						title="Reference points"
+						description="Use the original protocol docs as a companion while reading this local implementation."
+					/>
+
+					<nav class="mt-8 space-y-3">
+						<a v-for="resource in resources" :key="resource.url" :href="resource.url" target="_blank" rel="noreferrer noopener" class="flex items-center justify-between rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-gray-100 transition hover:border-yellow-300/30 hover:bg-yellow-300/10">
+							<span>{{ resource.label }}</span>
+							<span class="text-sm text-gray-400">Open</span>
+						</a>
+					</nav>
+
+					<div class="mt-6 rounded-2xl border border-dashed border-yellow-300/20 bg-yellow-300/10 p-5 text-sm leading-7 text-yellow-100/90">
+						Want the opposite setup? <Link :href="navigation.find((item) => item.key === 'widgets')?.href ?? '/'" class="font-semibold text-white underline decoration-yellow-300/40 underline-offset-4">Widget Workshop</Link> keeps the page server-rendered and only sprinkles Alpine on top.
+					</div>
+				</section>
+			</aside>
+		</div>
+	</ShowcaseShell>
+</template>

--- a/assets/js/pages/Vue/DemoApp.vue
+++ b/assets/js/pages/Vue/DemoApp.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+type ActivityItem = {
+	title: string;
+	time: string;
+	state: "ok" | "pending" | "warning";
+};
+
+const props = defineProps<{
+	metrics: Array<{
+		label: string;
+		value: string;
+		change: string;
+	}>;
+	panels: Array<{
+		title: string;
+		description: string;
+	}>;
+	activity: ActivityItem[];
+}>();
+
+const query = ref("");
+const showOnlyPending = ref(false);
+const compactMode = ref(false);
+const activeView = ref<"board" | "list">("board");
+
+const filteredActivity = computed(() => props.activity.filter((item) => {
+	const matchesQuery = query.value === "" || item.title.toLowerCase().includes(query.value.toLowerCase());
+	const matchesState = !showOnlyPending.value || item.state === "pending";
+
+	return matchesQuery && matchesState;
+}));
+
+const stateClasses: Record<ActivityItem["state"], string> = {
+	ok: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+	pending: "border-yellow-300/25 bg-yellow-300/10 text-yellow-100",
+	warning: "border-rose-300/25 bg-rose-300/10 text-rose-100",
+};
+</script>
+
+<template>
+	<div class="space-y-8">
+		<div class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+			<div class="flex flex-wrap items-start justify-between gap-6">
+				<div class="max-w-3xl">
+					<p class="text-xs font-semibold uppercase tracking-[0.28em] text-violet-500">Pure Vue app</p>
+					<h1 class="mt-3 text-4xl font-black tracking-tight text-gray-950">Vue Workbench</h1>
+					<p class="mt-4 text-lg leading-8 text-gray-600">This route is a normal Latte page with a dedicated Vue mount point. No Inertia protocol, no `data-page` envelope, just a focused client app running inside the existing Nette shell.</p>
+				</div>
+
+				<div class="flex flex-wrap gap-3">
+					<button class="rounded-full border px-4 py-2 text-sm transition" :class="activeView === 'board' ? 'border-violet-300 bg-violet-50 text-violet-700' : 'border-gray-200 text-gray-600 hover:border-violet-300 hover:text-violet-700'" @click="activeView = 'board'">Board view</button>
+					<button class="rounded-full border px-4 py-2 text-sm transition" :class="activeView === 'list' ? 'border-violet-300 bg-violet-50 text-violet-700' : 'border-gray-200 text-gray-600 hover:border-violet-300 hover:text-violet-700'" @click="activeView = 'list'">List view</button>
+				</div>
+			</div>
+		</div>
+
+		<section class="grid gap-4 md:grid-cols-3">
+			<article v-for="metric in metrics" :key="metric.label" class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+				<p class="text-sm font-medium text-gray-500">{{ metric.label }}</p>
+				<p class="mt-4 text-4xl font-black text-gray-950">{{ metric.value }}</p>
+				<p class="mt-3 text-sm text-violet-600">{{ metric.change }}</p>
+			</article>
+		</section>
+
+		<section class="grid gap-8 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+			<aside class="space-y-6 rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+				<div>
+					<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Workbench</p>
+					<h2 class="mt-3 text-2xl font-bold text-gray-950">Local control surface</h2>
+					<p class="mt-3 text-sm leading-7 text-gray-600">This side of the page exists purely for client-owned controls and does not need to round-trip through Inertia.</p>
+				</div>
+
+				<div class="space-y-4">
+					<label class="block text-sm text-gray-700">
+						<span class="mb-2 block font-medium text-gray-950">Search activity</span>
+						<input v-model="query" type="text" placeholder="Filter by title" class="w-full rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-gray-900 placeholder:text-gray-400 focus:border-violet-300 focus:bg-white focus:outline-none focus:ring-0" />
+					</label>
+
+					<label class="flex items-center justify-between rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700">
+						<span>Only pending items</span>
+						<input v-model="showOnlyPending" type="checkbox" class="rounded border-gray-300 text-violet-500 focus:ring-violet-300" />
+					</label>
+
+					<label class="flex items-center justify-between rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700">
+						<span>Compact mode</span>
+						<input v-model="compactMode" type="checkbox" class="rounded border-gray-300 text-violet-500 focus:ring-violet-300" />
+					</label>
+				</div>
+
+				<div class="space-y-3">
+					<article v-for="panel in panels" :key="panel.title" class="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+						<h3 class="text-base font-semibold text-gray-950">{{ panel.title }}</h3>
+						<p class="mt-2 text-sm leading-7 text-gray-600">{{ panel.description }}</p>
+					</article>
+				</div>
+			</aside>
+
+			<section class="rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+				<div class="flex flex-wrap items-center justify-between gap-4">
+					<div>
+						<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Workspace</p>
+						<h2 class="mt-3 text-2xl font-bold text-gray-950">{{ activeView === 'board' ? 'Board canvas' : 'List console' }}</h2>
+					</div>
+					<p class="text-sm text-gray-500">{{ filteredActivity.length }} items shown</p>
+				</div>
+
+				<div class="mt-8" :class="activeView === 'board' ? 'grid gap-4 md:grid-cols-2' : 'space-y-4'">
+					<article
+						v-for="item in filteredActivity"
+						:key="item.title"
+						class="rounded-2xl border border-gray-200 bg-gray-50 transition"
+						:class="compactMode ? 'px-4 py-3' : 'px-5 py-5'"
+					>
+						<div class="flex flex-wrap items-center justify-between gap-3">
+							<div>
+								<h3 class="text-lg font-semibold text-gray-950">{{ item.title }}</h3>
+								<p class="mt-1 text-sm text-gray-500">{{ item.time }}</p>
+							</div>
+							<span class="rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.2em]" :class="stateClasses[item.state]">
+								{{ item.state }}
+							</span>
+						</div>
+					</article>
+
+					<div v-if="filteredActivity.length === 0" class="rounded-2xl border border-dashed border-gray-300 px-5 py-8 text-center text-sm leading-7 text-gray-500">
+						No activity matches the current filters. This is all local page state managed by Vue only.
+					</div>
+				</div>
+			</section>
+
+			<aside class="space-y-6 rounded-[1.75rem] border border-gray-200 bg-white p-6 shadow-sm">
+				<div>
+					<p class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-500">Why this route exists</p>
+					<h2 class="mt-3 text-2xl font-bold text-gray-950">A Vue app without Inertia in the middle</h2>
+				</div>
+
+				<div class="space-y-4 text-sm leading-7 text-gray-600">
+					<p>Use this shape when the page is effectively a self-contained tool and the client should own filtering, view state, and contextual interactions.</p>
+					<p>The surrounding Nette page still exists, but the app itself mounts through its own Vite entrypoint and does not depend on the Inertia protocol.</p>
+					<p>That makes the contrast with the Inertia route explicit rather than conceptual.</p>
+				</div>
+			</aside>
+		</section>
+	</div>
+</template>

--- a/assets/js/site.ts
+++ b/assets/js/site.ts
@@ -1,0 +1,19 @@
+import "./../css/tailwind.css";
+import Alpine from "alpinejs";
+import collapse from "@alpinejs/collapse";
+import { init as initNette } from "./ui/nette";
+
+declare global {
+	interface Window {
+		__uiSkeletonBooted?: boolean;
+		Alpine: typeof Alpine;
+	}
+}
+
+if (!window.__uiSkeletonBooted) {
+	Alpine.plugin(collapse);
+	window.Alpine = Alpine;
+	Alpine.start();
+	initNette();
+	window.__uiSkeletonBooted = true;
+}

--- a/assets/js/vue-demo.ts
+++ b/assets/js/vue-demo.ts
@@ -1,0 +1,10 @@
+import { createApp } from "vue";
+import DemoApp from "./pages/Vue/DemoApp.vue";
+
+const target = document.querySelector<HTMLElement>("#vue-demo");
+const payload = document.querySelector<HTMLScriptElement>("#vue-demo-props");
+
+if (target !== null) {
+	const props = payload?.textContent ? JSON.parse(payload.textContent) : {};
+	createApp(DemoApp, props).mount(target);
+}

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,22 @@
   ],
   "license": "MIT",
   "type": "project",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../ui",
+      "options": {
+        "symlink": true,
+        "versions": {
+          "contributte/ui": "0.3.x-dev"
+        }
+      }
+    }
+  ],
   "require": {
     "php": "^8.4",
     "contributte/nella": "^0.3",
-    "contributte/ui": "^0.2"
+    "contributte/ui": "^0.3@dev"
   },
   "require-dev": {
     "contributte/qa": "^0.4",

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,14 @@
   "type": "project",
   "repositories": [
     {
-      "type": "path",
-      "url": "../ui",
-      "options": {
-        "symlink": true,
-        "versions": {
-          "contributte/ui": "0.3.x-dev"
-        }
-      }
+      "type": "vcs",
+      "url": "git@github.com:ohmyfelix/ui.git"
     }
   ],
   "require": {
     "php": "^8.4",
     "contributte/nella": "^0.3",
-    "contributte/ui": "^0.3@dev"
+    "contributte/ui": "dev-feat/inertia-support"
   },
   "require-dev": {
     "contributte/qa": "^0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9039d7c76d9c22986ce2701b18dbbd95",
+    "content-hash": "3f476ae47f4f4b3bbcadcf62bf2184bb",
     "packages": [
         {
             "name": "contributte/application",
@@ -533,11 +533,17 @@
         },
         {
             "name": "contributte/ui",
-            "version": "0.3.x-dev",
+            "version": "dev-feat/inertia-support",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ohmyfelix/ui.git",
+                "reference": "28eee4d68a5392d4cf7903f84bbafe86b5c0d8fc"
+            },
             "dist": {
-                "type": "path",
-                "url": "../ui",
-                "reference": "f75590fa924fd704854478c1aefa13c23beb683c"
+                "type": "zip",
+                "url": "https://api.github.com/repos/ohmyfelix/ui/zipball/28eee4d68a5392d4cf7903f84bbafe86b5c0d8fc",
+                "reference": "28eee4d68a5392d4cf7903f84bbafe86b5c0d8fc",
+                "shasum": ""
             },
             "require": {
                 "latte/latte": "^3.0.12",
@@ -589,10 +595,16 @@
                 "nette",
                 "ui"
             ],
-            "transport-options": {
-                "symlink": true,
-                "relative": true
-            }
+            "support": {
+                "source": "https://github.com/ohmyfelix/ui/tree/feat/inertia-support"
+            },
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/f3l1x"
+                }
+            ],
+            "time": "2026-03-26T10:55:23+00:00"
         },
         {
             "name": "contributte/utils",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e37d649653893e5c3d8d1f68b846300a",
+    "content-hash": "9039d7c76d9c22986ce2701b18dbbd95",
     "packages": [
         {
             "name": "contributte/application",
@@ -533,28 +533,24 @@
         },
         {
             "name": "contributte/ui",
-            "version": "v0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/contributte/ui.git",
-                "reference": "5b35aed2e707092f2c8d817f84431856c6026e0c"
-            },
+            "version": "0.3.x-dev",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/contributte/ui/zipball/5b35aed2e707092f2c8d817f84431856c6026e0c",
-                "reference": "5b35aed2e707092f2c8d817f84431856c6026e0c",
-                "shasum": ""
+                "type": "path",
+                "url": "../ui",
+                "reference": "f75590fa924fd704854478c1aefa13c23beb683c"
             },
             "require": {
                 "latte/latte": "^3.0.12",
+                "nette/application": "^3.2",
                 "nette/di": "^3.1.8",
+                "nette/http": "^3.3",
                 "nette/utils": "^4.0.3",
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "contributte/phpstan": "^0.1",
-                "contributte/qa": "^0.4",
-                "contributte/tester": "^0.4",
+                "contributte/phpstan": "~0.1.0",
+                "contributte/qa": "~0.4.0",
+                "contributte/tester": "~0.4.0",
                 "mockery/mockery": "^1.3.5"
             },
             "type": "library",
@@ -568,7 +564,11 @@
                     "Contributte\\UI\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -589,21 +589,10 @@
                 "nette",
                 "ui"
             ],
-            "support": {
-                "issues": "https://github.com/contributte/ui/issues",
-                "source": "https://github.com/contributte/ui/tree/v0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://contributte.org/partners.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/f3l1x",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-12-13T14:05:57+00:00"
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
         },
         {
             "name": "contributte/utils",
@@ -684,16 +673,16 @@
         },
         {
             "name": "latte/latte",
-            "version": "v3.1.1",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/latte.git",
-                "reference": "cb98e705eeb0fd18f1f1c5cfe1a5f6217f9fa8b3"
+                "reference": "d9f96802ef103705f8a389cd66cbf830d470b537"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/latte/zipball/cb98e705eeb0fd18f1f1c5cfe1a5f6217f9fa8b3",
-                "reference": "cb98e705eeb0fd18f1f1c5cfe1a5f6217f9fa8b3",
+                "url": "https://api.github.com/repos/nette/latte/zipball/d9f96802ef103705f8a389cd66cbf830d470b537",
+                "reference": "d9f96802ef103705f8a389cd66cbf830d470b537",
                 "shasum": ""
             },
             "require": {
@@ -707,9 +696,11 @@
             },
             "require-dev": {
                 "nette/php-generator": "^4.0",
-                "nette/tester": "^2.5",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
                 "nette/utils": "^4.0",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.10"
             },
             "suggest": {
@@ -767,9 +758,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/latte/issues",
-                "source": "https://github.com/nette/latte/tree/v3.1.1"
+                "source": "https://github.com/nette/latte/tree/v3.1.3"
             },
-            "time": "2025-12-18T22:30:40+00:00"
+            "time": "2026-03-22T23:12:17+00:00"
         },
         {
             "name": "nette/application",
@@ -1328,16 +1319,16 @@
         },
         {
             "name": "nette/php-generator",
-            "version": "v4.2.1",
+            "version": "v4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/php-generator.git",
-                "reference": "52aff4d9b12f20ca9f3e31a559b646d2fd21dd61"
+                "reference": "0d7060926f5c3e8c488b9b9ced42d857f12a34b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/52aff4d9b12f20ca9f3e31a559b646d2fd21dd61",
-                "reference": "52aff4d9b12f20ca9f3e31a559b646d2fd21dd61",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/0d7060926f5c3e8c488b9b9ced42d857f12a34b5",
+                "reference": "0d7060926f5c3e8c488b9b9ced42d857f12a34b5",
                 "shasum": ""
             },
             "require": {
@@ -1346,9 +1337,11 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.6",
                 "nikic/php-parser": "^5.0",
-                "phpstan/phpstan": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.40@stable",
                 "tracy/tracy": "^2.8"
             },
             "suggest": {
@@ -1394,22 +1387,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/php-generator/issues",
-                "source": "https://github.com/nette/php-generator/tree/v4.2.1"
+                "source": "https://github.com/nette/php-generator/tree/v4.2.2"
             },
-            "time": "2026-02-09T05:43:31+00:00"
+            "time": "2026-02-26T00:58:33+00:00"
         },
         {
             "name": "nette/robot-loader",
-            "version": "v4.1.1",
+            "version": "v4.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/robot-loader.git",
-                "reference": "fb255f5da2676d58863bef1716baf52993c7ffec"
+                "reference": "ad3f4be7a9cd8a95ccc7596a1c4982a3b103d91e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/robot-loader/zipball/fb255f5da2676d58863bef1716baf52993c7ffec",
-                "reference": "fb255f5da2676d58863bef1716baf52993c7ffec",
+                "url": "https://api.github.com/repos/nette/robot-loader/zipball/ad3f4be7a9cd8a95ccc7596a1c4982a3b103d91e",
+                "reference": "ad3f4be7a9cd8a95ccc7596a1c4982a3b103d91e",
                 "shasum": ""
             },
             "require": {
@@ -1418,8 +1411,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.6",
-                "phpstan/phpstan": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.9"
             },
             "type": "library",
@@ -1463,22 +1458,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/robot-loader/issues",
-                "source": "https://github.com/nette/robot-loader/tree/v4.1.1"
+                "source": "https://github.com/nette/robot-loader/tree/v4.1.2"
             },
-            "time": "2026-02-08T03:51:26+00:00"
+            "time": "2026-02-23T04:18:24+00:00"
         },
         {
             "name": "nette/routing",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/routing.git",
-                "reference": "14c466f3383add0d4f78a82074d3c9841f8edf47"
+                "reference": "92c0f7f89bdc5f93adec24b2ed7bb0c10e2550a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/routing/zipball/14c466f3383add0d4f78a82074d3c9841f8edf47",
-                "reference": "14c466f3383add0d4f78a82074d3c9841f8edf47",
+                "url": "https://api.github.com/repos/nette/routing/zipball/92c0f7f89bdc5f93adec24b2ed7bb0c10e2550a6",
+                "reference": "92c0f7f89bdc5f93adec24b2ed7bb0c10e2550a6",
                 "shasum": ""
             },
             "require": {
@@ -1487,8 +1482,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.9"
             },
             "type": "library",
@@ -1528,22 +1525,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/routing/issues",
-                "source": "https://github.com/nette/routing/tree/v3.1.2"
+                "source": "https://github.com/nette/routing/tree/v3.1.3"
             },
-            "time": "2025-10-31T00:55:27+00:00"
+            "time": "2026-02-23T04:05:29+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.4",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "086497a2f34b82fede9b5a41cc8e131d087cd8f7"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/086497a2f34b82fede9b5a41cc8e131d087cd8f7",
-                "reference": "086497a2f34b82fede9b5a41cc8e131d087cd8f7",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -1551,8 +1548,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.6",
-                "phpstan/phpstan": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -1593,22 +1592,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.4"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2026-02-08T02:54:00+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.2",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "f76b5dc3d6c6d3043c8d937df2698515b99cbaf5"
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/f76b5dc3d6c6d3043c8d937df2698515b99cbaf5",
-                "reference": "f76b5dc3d6c6d3043c8d937df2698515b99cbaf5",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
                 "shasum": ""
             },
             "require": {
@@ -1620,8 +1619,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -1682,9 +1683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.2"
+                "source": "https://github.com/nette/utils/tree/v4.1.3"
             },
-            "time": "2026-02-03T17:21:09+00:00"
+            "time": "2026-02-13T03:05:33+00:00"
         },
         {
             "name": "tracy/tracy",
@@ -2638,7 +2639,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "contributte/ui": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/config/config.neon
+++ b/config/config.neon
@@ -11,9 +11,14 @@ parameters:
 # ======================================
 # Extension ============================
 extensions:
+	inertia: Contributte\UI\DI\InertiaExtension
 
 # ======================================
 # Services =============================
+inertia:
+	manifest: %wwwDir%/dist/manifest.json
+	template: %appDir%/UI/@Templates/@inertia.latte
+
 services:
 	latte.latteFactory:
 		setup:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,21 @@
       "dependencies": {
         "@alpinejs/collapse": "^3.5.1",
         "@alpinejs/trap": "^3.7.0",
+        "@inertiajs/vue3": "^2.2.15",
         "alpinejs": "^3.9.5",
         "flatpickr": "^4.6.2",
         "naja": "^2.2.0",
         "nette-forms": "^3.0.0",
         "tippy.js": "^6.3.1",
-        "tom-select": "^2.0.0-rc.5"
+        "tom-select": "^2.0.0-rc.5",
+        "vue": "^3.5.17"
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/line-clamp": "^0.3.0",
         "@types/node": "^20.4.4",
+        "@vitejs/plugin-vue": "^1.10.2",
+        "@vue/compiler-sfc": "^3.5.17",
         "autoprefixer": "^10.4.0",
         "esbuild": "^0.13.15",
         "postcss": "^8.4.4",
@@ -42,12 +46,58 @@
         "focus-trap": "^6.6.1"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
       "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -68,6 +118,40 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@inertiajs/core": {
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.18.tgz",
+      "integrity": "sha512-StOszdE28nx9uxY4I28d7oLRGLdu/F9pRgWody2k29Qe9WqAoPHVQ5VJabTi2RTYHJXZrZZ+Wgtw3qVRZMrwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash-es": "^4.17.12",
+        "axios": "^1.13.5",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23",
+        "qs": "^6.15.0"
+      }
+    },
+    "node_modules/@inertiajs/vue3": {
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-2.3.18.tgz",
+      "integrity": "sha512-027MSfejuJi0Tz5thCbvr5jfEYdKNnTS5uWTmnEET/AOibL3c3wMr+Fp13vMA0TRbr/clGiCEq/57y8vNQsxGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inertiajs/core": "2.3.18",
+        "@types/lodash-es": "^4.17.12",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -147,11 +231,113 @@
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.4.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
       "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
       "dev": true
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.10.2.tgz",
+      "integrity": "sha512-/QJ0Z9qfhAFtKRY+r57ziY4BSbGUTGsPRMpB/Ron3QPwBZM4OZAZHdTa4a8PafCwU5DTatXG8TMDoP8z+oDqJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.5.10"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-dom/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-ssr/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.1.5",
@@ -160,6 +346,77 @@
       "dependencies": {
         "@vue/shared": "3.1.5"
       }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core/node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
     },
     "node_modules/@vue/shared": {
       "version": "3.1.5",
@@ -225,6 +482,12 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.12",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
@@ -256,6 +519,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -305,6 +579,35 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase-css": {
@@ -359,6 +662,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -371,11 +686,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/detective": {
       "version": "5.2.1",
@@ -406,11 +736,82 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.266",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.266.tgz",
       "integrity": "sha512-saJTYECxUSv7eSpnXw0XIEvUkP9x4s/x2mm3TVX7k4rIFS6f5TjBih1B5h437WzIhHQjid+d8ouQzPQskMervQ==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.13.15",
@@ -719,6 +1120,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -769,6 +1176,42 @@
         "tabbable": "^5.3.3"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
@@ -797,10 +1240,50 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -814,6 +1297,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -824,6 +1319,45 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/immutable": {
@@ -888,6 +1422,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/laravel-precognition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.2.tgz",
+      "integrity": "sha512-0H08JDdMWONrL/N314fvsO3FATJwGGlFKGkMF3nNmizVFJaWs17816iM+sX7Rp8d5hUjYCx6WLfsehSKfaTxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.4.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
@@ -895,6 +1439,30 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge2": {
@@ -917,6 +1485,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mini-svg-data-uri": {
@@ -943,10 +1532,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -992,6 +1587,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -999,10 +1606,10 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1026,10 +1633,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
-      "dev": true,
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1038,12 +1644,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1151,6 +1762,27 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1294,11 +1926,83 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/source-map-js": {
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1791,6 +2495,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/vue": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue/node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -1824,6 +2555,24 @@
         "focus-trap": "^6.6.1"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
+    },
+    "@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "requires": {
+        "@babel/types": "^7.29.0"
+      }
+    },
     "@babel/runtime": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
@@ -1832,12 +2581,49 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "requires": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      }
+    },
     "@esbuild/linux-loong64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
       "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
       "dev": true,
       "optional": true
+    },
+    "@inertiajs/core": {
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.18.tgz",
+      "integrity": "sha512-StOszdE28nx9uxY4I28d7oLRGLdu/F9pRgWody2k29Qe9WqAoPHVQ5VJabTi2RTYHJXZrZZ+Wgtw3qVRZMrwOA==",
+      "requires": {
+        "@types/lodash-es": "^4.17.12",
+        "axios": "^1.13.5",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23",
+        "qs": "^6.15.0"
+      }
+    },
+    "@inertiajs/vue3": {
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-2.3.18.tgz",
+      "integrity": "sha512-027MSfejuJi0Tz5thCbvr5jfEYdKNnTS5uWTmnEET/AOibL3c3wMr+Fp13vMA0TRbr/clGiCEq/57y8vNQsxGg==",
+      "requires": {
+        "@inertiajs/core": "2.3.18",
+        "@types/lodash-es": "^4.17.12",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1899,11 +2685,105 @@
       "dev": true,
       "requires": {}
     },
+    "@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
+    },
+    "@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/node": {
       "version": "20.4.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
       "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
       "dev": true
+    },
+    "@vitejs/plugin-vue": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.10.2.tgz",
+      "integrity": "sha512-/QJ0Z9qfhAFtKRY+r57ziY4BSbGUTGsPRMpB/Ron3QPwBZM4OZAZHdTa4a8PafCwU5DTatXG8TMDoP8z+oDqJw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "requires": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
+        }
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "requires": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
+        }
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "requires": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
+        }
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "requires": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
+        }
+      }
     },
     "@vue/reactivity": {
       "version": "3.1.5",
@@ -1911,6 +2791,72 @@
       "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
       "requires": {
         "@vue/shared": "3.1.5"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "requires": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "dependencies": {
+        "@vue/reactivity": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+          "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+          "requires": {
+            "@vue/shared": "3.5.30"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
+        }
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "requires": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      },
+      "dependencies": {
+        "@vue/reactivity": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+          "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+          "requires": {
+            "@vue/shared": "3.5.30"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
+        }
+      }
+    },
+    "@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "requires": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
+        }
       }
     },
     "@vue/shared": {
@@ -1965,6 +2911,11 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "autoprefixer": {
       "version": "10.4.12",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
@@ -1977,6 +2928,16 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "requires": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "binary-extensions": {
@@ -2004,6 +2965,24 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "camelcase-css": {
@@ -2034,17 +3013,35 @@
         "readdirp": "~3.6.0"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detective": {
       "version": "5.2.1",
@@ -2069,11 +3066,55 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.266",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.266.tgz",
       "integrity": "sha512-saJTYECxUSv7eSpnXw0XIEvUkP9x4s/x2mm3TVX7k4rIFS6f5TjBih1B5h437WzIhHQjid+d8ouQzPQskMervQ==",
       "dev": true
+    },
+    "entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
     },
     "esbuild": {
       "version": "0.13.15",
@@ -2246,6 +3287,11 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -2290,6 +3336,23 @@
         "tabbable": "^5.3.3"
       }
     },
+    "follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
+    },
+    "form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fraction.js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
@@ -2304,10 +3367,35 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "glob-parent": {
       "version": "5.1.2",
@@ -2318,6 +3406,11 @@
         "is-glob": "^4.0.1"
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2325,6 +3418,27 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "immutable": {
@@ -2374,11 +3488,38 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "laravel-precognition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.2.tgz",
+      "integrity": "sha512-0H08JDdMWONrL/N314fvsO3FATJwGGlFKGkMF3nNmizVFJaWs17816iM+sX7Rp8d5hUjYCx6WLfsehSKfaTxjg==",
+      "requires": {
+        "axios": "^1.4.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "lilconfig": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
       "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
+    },
+    "magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "merge2": {
       "version": "1.4.1",
@@ -2394,6 +3535,19 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mini-svg-data-uri": {
@@ -2417,10 +3571,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
     },
     "nette-forms": {
       "version": "3.3.1",
@@ -2451,6 +3604,11 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2458,10 +3616,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -2476,14 +3633,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
-      "dev": true,
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "requires": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "postcss-import": {
@@ -2540,6 +3696,19 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "requires": {
+        "side-channel": "^1.1.0"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -2624,11 +3793,54 @@
         "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
-    "source-map-js": {
+    "side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      }
+    },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -2890,6 +4102,25 @@
           "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
           "dev": true,
           "optional": true
+        }
+      }
+    },
+    "vue": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+      "requires": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.5.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+          "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "dependencies": {
+    "@inertiajs/vue3": "^2.2.15",
     "@alpinejs/collapse": "^3.5.1",
     "@alpinejs/trap": "^3.7.0",
     "alpinejs": "^3.9.5",
@@ -10,9 +11,12 @@
     "naja": "^2.2.0",
     "nette-forms": "^3.0.0",
     "tippy.js": "^6.3.1",
-    "tom-select": "^2.0.0-rc.5"
+    "tom-select": "^2.0.0-rc.5",
+    "vue": "^3.5.17"
   },
   "devDependencies": {
+    "@vitejs/plugin-vue": "^1.10.2",
+    "@vue/compiler-sfc": "^3.5.17",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/line-clamp": "^0.3.0",
     "@types/node": "^20.4.4",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
 		"./app/**/*.php",
 		"./assets/css/tailwind/**/*.css",
 		"./assets/**/*.js",
+		"./assets/**/*.vue",
 	],
 	safelist: [`
 		hidden w-full border-0

--- a/tests/Cases/E2E/Inertia/HomePresenterTest.php
+++ b/tests/Cases/E2E/Inertia/HomePresenterTest.php
@@ -47,7 +47,7 @@ final class HomePresenterTest extends TestCase
 
 		Assert::contains('data-page=', $output);
 		Assert::contains('Home/Index', $output);
-		Assert::contains('app.', $output);
+		Assert::contains('/dist/inertia.', $output);
 	}
 
 }

--- a/tests/Cases/E2E/Inertia/HomePresenterTest.php
+++ b/tests/Cases/E2E/Inertia/HomePresenterTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\E2E\Inertia;
+
+use App\Bootstrap;
+use Contributte\Utils\FileSystem;
+use Nette\Application\IPresenterFactory;
+use Nette\Application\Request;
+use Nette\Application\Responses\TextResponse;
+use Tester\Assert;
+use Tester\TestCase;
+use Tests\Toolkit\Tests;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+final class HomePresenterTest extends TestCase
+{
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		if (!file_exists(Tests::ROOT_PATH . '/config/local.neon')) {
+			FileSystem::copy(
+				Tests::ROOT_PATH . '/config/local.neon.example',
+				Tests::ROOT_PATH . '/config/local.neon'
+			);
+		}
+	}
+
+	public function testHomepageRendersInertiaShell(): void
+	{
+		$container = Bootstrap::boot()->createContainer();
+		$presenterFactory = $container->getByType(IPresenterFactory::class);
+		$presenter = $presenterFactory->createPresenter('Home');
+		$response = $presenter->run(new Request('Home', 'GET', ['action' => 'default']));
+
+		Assert::type(TextResponse::class, $response);
+		assert($response instanceof TextResponse);
+
+		ob_start();
+		$response->send(
+			$container->getService('http.request'),
+			$container->getService('http.response')
+		);
+		$output = (string) ob_get_clean();
+
+		Assert::contains('data-page=', $output);
+		Assert::contains('Home/Index', $output);
+		Assert::contains('app.', $output);
+	}
+
+}
+
+(new HomePresenterTest())->run();

--- a/tests/Cases/E2E/Inertia/ShowcasePresenterTest.php
+++ b/tests/Cases/E2E/Inertia/ShowcasePresenterTest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\E2E\Inertia;
+
+use App\Bootstrap;
+use Contributte\Utils\FileSystem;
+use Nette\Application\IPresenterFactory;
+use Nette\Application\Request;
+use Nette\Application\Responses\TextResponse;
+use Tester\Assert;
+use Tester\TestCase;
+use Tests\Toolkit\Tests;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+final class ShowcasePresenterTest extends TestCase
+{
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		if (!file_exists(Tests::ROOT_PATH . '/config/local.neon')) {
+			FileSystem::copy(
+				Tests::ROOT_PATH . '/config/local.neon.example',
+				Tests::ROOT_PATH . '/config/local.neon'
+			);
+		}
+	}
+
+	public function testInertiaActionRendersInertiaShell(): void
+	{
+		$container = Bootstrap::boot()->createContainer();
+		$presenterFactory = $container->getByType(IPresenterFactory::class);
+		$presenter = $presenterFactory->createPresenter('Showcase');
+		$response = $presenter->run(new Request('Showcase', 'GET', ['action' => 'inertia']));
+
+		Assert::type(TextResponse::class, $response);
+		assert($response instanceof TextResponse);
+
+		ob_start();
+		$response->send(
+			$container->getService('http.request'),
+			$container->getService('http.response')
+		);
+		$output = (string) ob_get_clean();
+
+		Assert::contains('data-page=', $output);
+		Assert::contains('Showcase/Inertia', $output);
+	}
+
+	public function testWidgetsActionRendersClassicLattePage(): void
+	{
+		$container = Bootstrap::boot()->createContainer();
+		$presenterFactory = $container->getByType(IPresenterFactory::class);
+		$presenter = $presenterFactory->createPresenter('Showcase');
+		$response = $presenter->run(new Request('Showcase', 'GET', ['action' => 'widgets']));
+
+		Assert::type(TextResponse::class, $response);
+		assert($response instanceof TextResponse);
+
+		ob_start();
+		$response->send(
+			$container->getService('http.request'),
+			$container->getService('http.response')
+		);
+		$output = (string) ob_get_clean();
+
+		Assert::contains('Widget Workshop', $output);
+		Assert::contains('Hover for hint', $output);
+		Assert::notContains('data-page=', $output);
+	}
+
+	public function testVueActionRendersStandaloneMountPoint(): void
+	{
+		$container = Bootstrap::boot()->createContainer();
+		$presenterFactory = $container->getByType(IPresenterFactory::class);
+		$presenter = $presenterFactory->createPresenter('Showcase');
+		$response = $presenter->run(new Request('Showcase', 'GET', ['action' => 'vue']));
+
+		Assert::type(TextResponse::class, $response);
+		assert($response instanceof TextResponse);
+
+		ob_start();
+		$response->send(
+			$container->getService('http.request'),
+			$container->getService('http.response')
+		);
+		$output = (string) ob_get_clean();
+
+		Assert::contains('id="vue-demo"', $output);
+		Assert::contains('vue-demo-props', $output);
+		Assert::notContains('data-page=', $output);
+	}
+
+}
+
+(new ShowcasePresenterTest())->run();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import vue from '@vitejs/plugin-vue';
 
 export default defineConfig(({ mode }) => {
 	const DEV = mode === 'development';
 
 	return {
+		plugins: [vue()],
 		resolve: {
 			alias: {
 				'@': resolve(__dirname, 'assets/js'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig(({ mode }) => {
 	const DEV = mode === 'development';
 
 	return {
+		base: '/dist/',
 		plugins: [vue()],
 		resolve: {
 			alias: {
@@ -31,7 +32,9 @@ export default defineConfig(({ mode }) => {
 					assetFileNames: DEV ? '[name].[ext]' : '[name].[hash].[ext]',
 				},
 				input: {
-					app: './assets/js/app.ts'
+					site: './assets/js/site.ts',
+					inertia: './assets/js/inertia.ts',
+					vueDemo: './assets/js/vue-demo.ts',
 				}
 			}
 		},

--- a/www/favicon.svg
+++ b/www/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="18" fill="#111827"/>
+  <path d="M19 21h26v6H19z" fill="#F59E0B"/>
+  <path d="M19 29h18v6H19z" fill="#22D3EE"/>
+  <path d="M19 37h26v6H19z" fill="#A78BFA"/>
+</svg>

--- a/www/robots.txt
+++ b/www/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
## What changed
- wire `contributte/ui` Inertia support into the skeleton and keep an Inertia-driven app page for the server-authored flow
- split the showcase into three distinct demos: an Inertia app, a pure Latte + Alpine widget workshop, and a standalone Vue workspace without Inertia
- separate the frontend runtime into dedicated Vite entries (`site.ts`, `inertia.ts`, `vue-demo.ts`), add smoke coverage for the new pages, and fix built asset paths for proxy/nested routes

## Why
- the skeleton should show when to use each rendering model instead of blending everything into one hybrid page
- this makes the Inertia example easier to understand while also preserving classic Nette/Latte patterns and a truly standalone Vue setup

## Notes
- this PR currently depends on `contributte/ui` branch `feat/inertia-support` from my fork via Composer VCS so CI can exercise the new package before it is merged upstream
- unrelated local change in `.github/workflows/coverage.yml` was intentionally left out of this branch
